### PR TITLE
[Feat] Add assessmentItemID_time_level #92

### DIFF
--- a/src/tabular/model_configs/default_config.py
+++ b/src/tabular/model_configs/default_config.py
@@ -30,6 +30,7 @@ FEATS = [
     'time_to_solve_mean',
     #  'prior_assessment_frequency',
     #  'prior_KnowledgeTag_frequency',
+    'assessmentItemID_time_level',
     'prior_testTag_frequency'
  ]
 

--- a/src/tabular/module/dataloader.py
+++ b/src/tabular/module/dataloader.py
@@ -132,9 +132,18 @@ class Preprocess:
         # 결측치 이전 행의 값으로 채움
         df['time_to_solve'].fillna(method='ffill', inplace=True)
 
+        # 추가 이상치 처리
+        df.loc[df['time_to_solve'] >= 1000, 'time_to_solve'] = 1000
+
         # 유저별 문항 시간 평균
         #df['time_to_solve_mean'] = df.groupby('userID')['time_to_solve'].transform('mean')
         df['time_to_solve_mean'] = df.groupby(['userID', 'testId'])['time_to_solve'].transform('mean')
+
+        # 문항당 문제를 푸는 평균시간
+        df['assessmentItemID_time_to_solve_mean'] = df.groupby('assessmentItemID')['time_to_solve'].transform('mean')
+
+        # 유저의 문제 푸는 시간 이용하여, 레벨 처리 
+        df['assessmentItemID_time_level'] = df['assessmentItemID_time_to_solve_mean'] - df['time_to_solve']
 
         # clip(0, 255)는 메모리를 위해 uint8 데이터 타입을 쓰기 위함
         df['prior_assessment_frequency'] = df.groupby(['userID', 'assessmentItemID']).cumcount().clip(0, 255)


### PR DESCRIPTION
## Overview
- Feature Engineering 및 많은 실험을 통해 유의미한 피처 추가 및 업데이트하였습니다.

## Change Log

- default_config.py, dataloader.py 변경
    - `assessmentItemID_time_level` 추가

## To Reviewer

- `time_to_solve` 이상치 처리 
- `assessmentItemID_time_to_solve_mean` 추가
- `assessmentItemID_time_level` 추가


- 유의미한 피처 정리 총 14개 
  - cate : `KnowledgeTag`, `testTag`
  - num : 위 제외 12개 
  - FEATS = ['KnowledgeTag', 'Dffclt', 'Dscrmn', 'Gussng', 'testTag', 'user_correct_answer', 'user_total_answer', 'user_acc', 'user_mean', 'relative_answer_mean', 'time_to_solve', 'time_to_solve_mean', 'assessmentItemID_time_level', 'prior_testTag_frequency']


## Issue Tags
- resolved: #92 
- See also: #43 
